### PR TITLE
Load installed plugin's composer dependencies

### DIFF
--- a/ShyimPluginManager.php
+++ b/ShyimPluginManager.php
@@ -7,6 +7,7 @@ use Shopware\Components\Plugin\Context\InstallContext;
 use Symfony\Component\DependencyInjection\ContainerBuilder;
 
 require(__DIR__ . '/vendor/autoload.php');
+require(__DIR__ . '/../../composer/vendor/autoload.php');
 
 /**
  * Class ShyimPluginManager


### PR DESCRIPTION
I installed the WhoopsForSHopware plugin via your plugin manager. Plugin got installed, composer dependencies for the plugin got installed. I got an error, that the whoops classes were not be loaded. You need to load the autoload.php somewhere.